### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/YahooAdapterBannerAd.swift
+++ b/Source/YahooAdapterBannerAd.swift
@@ -72,9 +72,8 @@ extension YahooAdapterBannerAd: YASInlineAdViewDelegate {
     }
     
     func inlineAdLoadDidFail(_ inlineAd: YASInlineAdView, withError errorInfo: YASErrorInfo) {
-        let error = error(.loadFailureUnknown, error: errorInfo)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(errorInfo))
+        loadCompletion?(.failure(errorInfo)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     

--- a/Source/YahooAdapterFullscreenAd.swift
+++ b/Source/YahooAdapterFullscreenAd.swift
@@ -63,16 +63,14 @@ extension YahooAdapterFullscreenAd: YASInterstitialAdDelegate {
     }
     
     func interstitialAdLoadDidFail(_ interstitialAd: YASInterstitialAd, withError errorInfo: YASErrorInfo) {
-        let error = error(.loadFailureUnknown, error: errorInfo)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(errorInfo))
+        loadCompletion?(.failure(errorInfo)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     
     func interstitialAdDidFail(_ interstitialAd: YASInterstitialAd, withError errorInfo: YASErrorInfo) {
-        let error = error(.showFailureUnknown, error: errorInfo)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(errorInfo))
+        showCompletion?(.failure(errorInfo)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
     


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
